### PR TITLE
fix wait-for-rabbitmq on mac

### DIFF
--- a/rabbitmq/wait-for-rabbitmq.sh
+++ b/rabbitmq/wait-for-rabbitmq.sh
@@ -2,9 +2,8 @@
 # Use this script to wait for rabbitmq to really be ready
 port=${1:-5672} # can override port from command line
 set -e
-until timeout 1 bash -c "cat < /dev/null > /dev/tcp/localhost/${port}"; do
+until bash -c "nc -z localhost ${port}"; do
   >&2 echo "Rabbit MQ not up yet on localhost:${port}"
   sleep 1
 done
-
-echo "Rabbit MQ is up"
+echo "Rabbit MQ is up on ${port}"


### PR DESCRIPTION
script worked on linux but not mac; tested to work on both now.

If it's still not working, you might need to run "make test-teardown" to remove an old rabbitmq container that's still running but doesn't have the recordswriter queue.