### PR TITLE
improve docker build speed; pass base url into uglyui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ deploy/awslambda/main.lambda.zip
 *.so
 *.dylib
 output-ourroots.cf.yaml
+uglyui/dist/
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile.publisher
+++ b/Dockerfile.publisher
@@ -1,7 +1,10 @@
 FROM golang:1.14
 EXPOSE 8000
 WORKDIR /cms/publisher
-COPY . /cms
+COPY go.mod /cms
+COPY go.sum /cms
+RUN go mod download
 RUN go get -u github.com/swaggo/swag/cmd/swag
+COPY . /cms
 RUN go generate && go build -o server
 CMD ./server

--- a/Dockerfile.recordswriter
+++ b/Dockerfile.recordswriter
@@ -1,7 +1,10 @@
 FROM golang:1.14
 EXPOSE 8000
 WORKDIR /cms/recordswriter
-COPY . /cms
+COPY go.mod /cms
+COPY go.sum /cms
+RUN go mod download
 RUN go get -u github.com/swaggo/swag/cmd/swag
+COPY . /cms
 RUN go generate && go build -o server
 CMD ./server

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,7 +1,10 @@
 FROM golang:1.14
 EXPOSE 8000
 WORKDIR /cms/server
-COPY . /cms
+COPY go.mod /cms
+COPY go.sum /cms
+RUN go mod download
 RUN go get -u github.com/swaggo/swag/cmd/swag
+COPY . /cms
 RUN go generate && go build -o server
 CMD ./server

--- a/README.md
+++ b/README.md
@@ -2,40 +2,25 @@
 
 To build and run this API, you will need a [Go 1.14+ installation](https://golang.org/dl/). 
 
-## Prerequisites
-
-* [Swag](https://github.com/swaggo/swag#getting-started)
-
-To use with a real database:
-* [Postgres](https://www.postgresql.org/download/)
-* [Migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate)
-
-## Building and Running
+## Getting Started
 
 Clone the repo:
 ```
 git clone https://github.com/ourrootsorg/cms-server.git
 ```
-In the `ourroots` directory, run `make` to run unit tests and build.
-
-## Database Setup
-
-After installing Postgres, cd into the `db` directory and run `./db_setup.sh` which should create the `cms` database and apply database migrations to create tables. Once that is done, you should be able to run the server using the database:
-```
-DATABASE_URL=postgres://ourroots:password@localhost:5432/cms?sslmode=disable ./server
-```
 
 ## Instructions for running server and uglyui client 
-#### requires docker-compose, tilt, psql, npm, and vue
+#### requires docker-compose, tilt, psql, npm, vue, and a few other things
 
 ```
+install swag                    # https://github.com/swaggo/swag#getting-started
+install migrate                 # https://github.com/golang-migrate/migrate/tree/master/cmd/migrate
 install docker                  # https://www.docker.com/ 
 install docker-compose          # https://docs.docker.com/compose/install/
                                   # no need to install docker-compose on mac since mac docker includes compose
 install tilt                    # https://tilt.dev/
                                   # optional but makes rebuilds much faster
                                   # ignore kubernetes and kubectl; you just need the one-line curl install
-                                  # on mac, you can use brew to install tilt
 install npm                     # https://nodejs.org/en/ 
                                   # node includes npm
 install psql                    # https://blog.timescale.com/tutorials/how-to-install-psql-on-mac-ubuntu-debian-windows/
@@ -44,22 +29,29 @@ npm install -g @vue/cli         # the uglyui client uses vue
 docker volume create cms_pgdata # do this once to create a persistent database volume
 docker volume create cms_s3data # do this once to create a persistent blob store volume
 docker volume create cms_esdata # do this once to create a persistent elasticsearch volume
+
 tilt up                         # run the server and dependencies
                                   # make sure you don't already have a postgres process running
                                   # alternatively, run docker-compose up --build
-cd db && ./db_setup.sh && cd ..   # do this once to set up the database
+cd db && ./db_setup.sh && cd .. # do this once to set up the database
                                   # make sure you have psql (postgres client) available on your path
 open http://localhost:9000      # launch the minio browser and create a bucket named "cmsbucket" -- do this once
 cd elasticsearch && ./es_setup.sh && cd ..   # do this once to set up elasticsearch
-tilt down && tilt up            # do this once after you've set up the database to restart the server
+tilt down                       # now that everything is set up, take everything down
+
+tilt up                         # restart everything once it has been set up above
                                   # alternatively, run docker-compose down && docker-compose up --build
-cd ../uglyui                    # the directory for the uglyui client
+cd uglyui                       # the directory for the uglyui client
 npm install                     # do this once, and again if you get a missing dependency error
 npm run serve                   # run the ugly client
                                 # make changes to either the server or client, everything reloads automatically
 tilt down                       # clean up docker images when done
                                   # alternatively, run docker-compose down
 ```
+
+# Building 
+
+In the `ourroots` directory, run `make` to run unit tests and build.
 
 # Saving and restoring elasticsearch volume data
 ### creates /tmp/cms_esdata.tar.bz2 from cms_esdata

--- a/api/api.go
+++ b/api/api.go
@@ -202,7 +202,7 @@ func (api *API) ElasticsearchConfig(esURL string) *API {
 	// ping elasticsearch to make sure we can connect
 	cnt := 0
 	err = errors.New("unknown error")
-	for err != nil && cnt <= 5 {
+	for err != nil && cnt <= 6 {
 		if cnt > 0 {
 			time.Sleep(time.Duration(math.Pow(2.0, float64(cnt))) * time.Second)
 		}

--- a/api/pubsub.go
+++ b/api/pubsub.go
@@ -24,7 +24,7 @@ func (api *API) OpenTopic(ctx context.Context, topicName string) (*pubsub.Topic,
 	urlStr := getPubSubURLStr(api.pubSubConfig.protocol, api.pubSubConfig.region, api.pubSubConfig.host, topicName)
 	conn := api.rabbitmqTopicConn
 	var topic *pubsub.Topic
-	for err != nil && cnt <= 4 {
+	for err != nil && cnt <= 5 {
 		if cnt > 0 {
 			time.Sleep(time.Duration(math.Pow(2.0, float64(cnt))) * time.Second)
 		}
@@ -36,6 +36,7 @@ func (api *API) OpenTopic(ctx context.Context, topicName string) (*pubsub.Topic,
 			if conn == nil {
 				conn, err = amqp.Dial(urlStr)
 				if err != nil {
+					log.Printf("[INFO] Rabbit dialed try %d error %v\n", cnt, err)
 					conn = nil
 					continue
 				}
@@ -61,7 +62,7 @@ func (api *API) OpenSubscription(ctx context.Context, queue string) (*pubsub.Sub
 	urlStr := getPubSubURLStr(api.pubSubConfig.protocol, api.pubSubConfig.region, api.pubSubConfig.host, queue)
 	conn := api.rabbitmqSubscriptionConn
 	var subscription *pubsub.Subscription
-	for err != nil && cnt <= 4 {
+	for err != nil && cnt <= 5 {
 		if cnt > 0 {
 			time.Sleep(time.Duration(math.Pow(2.0, float64(cnt))) * time.Second)
 		}
@@ -73,6 +74,7 @@ func (api *API) OpenSubscription(ctx context.Context, queue string) (*pubsub.Sub
 			if conn == nil {
 				conn, err = amqp.Dial(urlStr)
 				if err != nil {
+					log.Printf("[INFO] Rabbit dialed try %d error %v\n", cnt, err)
 					conn = nil
 					continue
 				}

--- a/uglyui/.env.development
+++ b/uglyui/.env.development
@@ -1,0 +1,1 @@
+VUE_APP_API_BASE_URL=http://localhost:8000

--- a/uglyui/.env.production
+++ b/uglyui/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_API_BASE_URL=/api

--- a/uglyui/flintstones.csv
+++ b/uglyui/flintstones.csv
@@ -1,0 +1,5 @@
+"Given","Surname"
+"Fred","Flintstone"
+"Wilma","Slaghoople"
+"Barney","Rubble"
+"Betty Jean","McBricker"

--- a/uglyui/src/services/Server.js
+++ b/uglyui/src/services/Server.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { getInstance } from "../auth";
 
 const apiClient = axios.create({
-  baseURL: `http://localhost:8000`,
+  baseURL: process.env.VUE_APP_API_BASE_URL,
   withCredentials: false, // This is the default
   headers: {
     Accept: "application/json",


### PR DESCRIPTION
Take a look at these changes:
* modified docker files to fetch dependencies before copying files. This means that dependencies are cached, which cuts build time in half
* builds are so fast now that I had to increase the amount of time we wait for rabbit and elasticsearch
* base url is now passed into uglyui via .env.development (npm run serve) or .env.production (npm run buld)