### PR TITLE
collections can belong to multiple categories

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,11 +34,13 @@ const UserProperty TokenKey = "user"
 
 type LocalAPI interface {
 	GetCategories(context.Context) (*CategoryResult, *model.Errors)
+	GetCategoriesByID(ctx context.Context, ids []uint32) ([]model.Category, *model.Errors)
 	GetCategory(ctx context.Context, id uint32) (*model.Category, *model.Errors)
 	AddCategory(ctx context.Context, in model.CategoryIn) (*model.Category, *model.Errors)
 	UpdateCategory(ctx context.Context, id uint32, in model.Category) (*model.Category, *model.Errors)
 	DeleteCategory(ctx context.Context, id uint32) *model.Errors
 	GetCollections(ctx context.Context /* filter/search criteria */) (*CollectionResult, *model.Errors)
+	GetCollectionsByID(ctx context.Context, ids []uint32) ([]model.Collection, *model.Errors)
 	GetCollection(ctx context.Context, id uint32) (*model.Collection, *model.Errors)
 	AddCollection(ctx context.Context, in model.CollectionIn) (*model.Collection, *model.Errors)
 	UpdateCollection(ctx context.Context, id uint32, in model.Collection) (*model.Collection, *model.Errors)

--- a/api/api_mock.go
+++ b/api/api_mock.go
@@ -17,6 +17,9 @@ type ApiMock struct {
 func (a *ApiMock) GetCategories(ctx context.Context) (*CategoryResult, *model.Errors) {
 	return a.Result.(*CategoryResult), a.Errors
 }
+func (a *ApiMock) GetCategoriesByID(ctx context.Context, ids []uint32) ([]model.Category, *model.Errors) {
+	return a.Result.([]model.Category), a.Errors
+}
 func (a *ApiMock) GetCategory(ctx context.Context, id uint32) (*model.Category, *model.Errors) {
 	return a.Result.(*model.Category), a.Errors
 }
@@ -31,6 +34,9 @@ func (a *ApiMock) DeleteCategory(ctx context.Context, id uint32) *model.Errors {
 }
 func (a *ApiMock) GetCollections(ctx context.Context /* filter/search criteria */) (*CollectionResult, *model.Errors) {
 	return a.Result.(*CollectionResult), a.Errors
+}
+func (a *ApiMock) GetCollectionsByID(ctx context.Context, ids []uint32) ([]model.Collection, *model.Errors) {
+	return a.Result.([]model.Collection), a.Errors
 }
 func (a *ApiMock) GetCollection(ctx context.Context, id uint32) (*model.Collection, *model.Errors) {
 	return a.Result.(*model.Collection), a.Errors

--- a/api/categories.go
+++ b/api/categories.go
@@ -45,6 +45,15 @@ func (api API) GetCategories(ctx context.Context /* filter/search criteria */) (
 	return &CategoryResult{Categories: cols}, nil
 }
 
+// GetCategoriesByID holds the business logic around getting many Categories
+func (api API) GetCategoriesByID(ctx context.Context, ids []uint32) ([]model.Category, *model.Errors) {
+	cats, err := api.categoryPersister.SelectCategoriesByID(ctx, ids)
+	if err != nil {
+		return nil, model.NewErrors(http.StatusInternalServerError, err)
+	}
+	return cats, nil
+}
+
 // GetCategory holds the business logic around getting a Category
 func (api API) GetCategory(ctx context.Context, id uint32) (*model.Category, *model.Errors) {
 	category, err := api.categoryPersister.SelectOneCategory(ctx, id)

--- a/api/collections.go
+++ b/api/collections.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -56,7 +57,7 @@ func (api API) AddCollection(ctx context.Context, in model.CollectionIn) (*model
 	collection, err := api.collectionPersister.InsertCollection(ctx, in)
 	if err == persist.ErrForeignKeyViolation {
 		log.Printf("[ERROR] Invalid category reference: %v", err)
-		return nil, model.NewErrors(http.StatusBadRequest, model.NewError(model.ErrBadReference, strconv.Itoa(int(in.Category)), "category"))
+		return nil, model.NewErrors(http.StatusBadRequest, model.NewError(model.ErrBadReference, fmt.Sprintf("%v", in.Categories), "categories"))
 	} else if err != nil {
 		log.Printf("[ERROR] Internal server error: %v", err)
 		return nil, model.NewErrors(http.StatusInternalServerError, err)
@@ -82,7 +83,7 @@ func (api API) UpdateCollection(ctx context.Context, id uint32, in model.Collect
 	}
 	if err == persist.ErrForeignKeyViolation {
 		log.Printf("[ERROR] Invalid category reference: %v", err)
-		return nil, model.NewErrors(http.StatusBadRequest, model.NewError(model.ErrBadReference, strconv.Itoa(int(in.Category)), "category"))
+		return nil, model.NewErrors(http.StatusBadRequest, model.NewError(model.ErrBadReference, fmt.Sprintf("%v", in.Categories), "categories"))
 	} else if err != nil {
 		return nil, model.NewErrors(http.StatusInternalServerError, err)
 	}

--- a/api/collections_test.go
+++ b/api/collections_test.go
@@ -48,16 +48,16 @@ func TestCollections(t *testing.T) {
 		CollectionBody: model.CollectionBody{
 			Name: "Test Collection",
 		},
-		Category: testCategory.ID,
+		Categories: []uint32{testCategory.ID},
 	}
 	created, errors := testApi.AddCollection(context.TODO(), in)
 	assert.Nil(t, errors)
 	assert.Equal(t, in.Name, created.Name, "Expected Name to match")
 	assert.NotEmpty(t, created.ID)
-	assert.Equal(t, in.Category, created.Category)
+	assert.Equal(t, in.Categories, created.Categories)
 
 	// Add with bad category reference
-	in.Category = in.Category + 88
+	in.Categories = []uint32{88}
 	_, errors = testApi.AddCollection(context.TODO(), in)
 	assert.Len(t, errors.Errs(), 1)
 	assert.Equal(t, model.ErrBadReference, errors.Errs()[0].Code, "errors.Errs()[0]: %#v", errors.Errs()[0])
@@ -81,7 +81,7 @@ func TestCollections(t *testing.T) {
 	assert.Equal(t, created, ret2)
 
 	// Bad request - no category
-	in.Category = 0
+	in.Categories = nil
 	_, errors = testApi.AddCollection(context.TODO(), in)
 	if assert.Len(t, errors.Errs(), 1, "errors.Errs(): %#v", errors.Errs()) {
 		assert.Equal(t, errors.Errs()[0].Code, model.ErrRequired)
@@ -98,7 +98,7 @@ func TestCollections(t *testing.T) {
 	updated, errors := testApi.UpdateCollection(context.TODO(), ret2.ID, *ret2)
 	assert.Nil(t, errors)
 	assert.Equal(t, ret2.ID, updated.ID)
-	assert.Equal(t, ret2.Category, updated.Category)
+	assert.Equal(t, ret2.Categories, updated.Categories)
 	assert.Equal(t, ret2.Name, updated.Name, "Expected Name to match")
 
 	// Update non-existant
@@ -107,13 +107,13 @@ func TestCollections(t *testing.T) {
 	assert.Equal(t, model.ErrNotFound, errors.Errs()[0].Code, "errors.Errs()[0]: %#v", errors.Errs()[0])
 
 	// Update with bad category
-	updated.Category = updated.Category + 99
+	updated.Categories = []uint32{99}
 	_, errors = testApi.UpdateCollection(context.TODO(), updated.ID, *updated)
 	assert.Len(t, errors.Errs(), 1)
 	assert.Equal(t, model.ErrBadReference, errors.Errs()[0].Code, "errors.Errs()[0]: %#v", errors.Errs()[0])
 
 	// Update with bad LastUpdateTime
-	updated.Category = ret2.Category
+	updated.Categories = ret2.Categories
 	updated.LastUpdateTime = time.Now().Add(-time.Minute)
 	_, errors = testApi.UpdateCollection(context.TODO(), updated.ID, *updated)
 	if assert.NotNil(t, errors) {

--- a/api/posts_test.go
+++ b/api/posts_test.go
@@ -129,7 +129,7 @@ func TestPosts(t *testing.T) {
 }
 
 func createTestCollection(p model.CollectionPersister, categoryID uint32) (*model.Collection, error) {
-	in := model.NewCollectionIn("Test", categoryID)
+	in := model.NewCollectionIn("Test", []uint32{categoryID})
 	in.Fields = []model.CollectionField{
 		{
 			Header: "given",

--- a/db/migrations/000006_collection_category_table.down.sql
+++ b/db/migrations/000006_collection_category_table.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE collection ADD COLUMN IF NOT EXISTS category_id INTEGER REFERENCES category (id);
+UPDATE collection SET category_id = (SELECT category_id FROM collection_category WHERE collection_id = id LIMIT 1);
+DROP TABLE IF EXISTS collection_category;

--- a/db/migrations/000006_collection_category_table.up.sql
+++ b/db/migrations/000006_collection_category_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS collection_category (
+  collection_id INTEGER REFERENCES collection (id),
+  category_id INTEGER REFERENCES category (id),
+  primary key (collection_id, category_id)
+);
+CREATE INDEX idx_collection_category_collection ON collection_category (collection_id);
+CREATE INDEX idx_collection_category_category ON collection_category (category_id);
+GRANT SELECT, INSERT, UPDATE, DELETE ON collection_category TO ourroots;
+
+INSERT INTO collection_category (collection_id, category_id) SELECT id, category_id from collection;
+ALTER TABLE collection DROP COLUMN IF EXISTS category_id;

--- a/model/category.go
+++ b/model/category.go
@@ -18,6 +18,7 @@ var pathPrefix string
 // CategoryPersister defines methods needed to persist categories
 type CategoryPersister interface {
 	SelectCategories(ctx context.Context) ([]Category, error)
+	SelectCategoriesByID(ctx context.Context, ids []uint32) ([]Category, error)
 	SelectOneCategory(ctx context.Context, id uint32) (Category, error)
 	InsertCategory(ctx context.Context, in CategoryIn) (Category, error)
 	UpdateCategory(ctx context.Context, id uint32, body Category) (Category, error)

--- a/model/collection.go
+++ b/model/collection.go
@@ -59,7 +59,7 @@ func (cb *CollectionBody) Scan(value interface{}) error {
 // CollectionIn is the payload to create or update a Collection
 type CollectionIn struct {
 	CollectionBody
-	Category uint32 `json:"category,omitempty" example:"999" validate:"required"`
+	Categories []uint32 `json:"categories" validate:"required"`
 }
 
 // Collection represents a set of related Records
@@ -71,12 +71,12 @@ type Collection struct {
 }
 
 // NewCollectionIn constructs a CollectionIn
-func NewCollectionIn(name string, categoryID uint32) CollectionIn {
+func NewCollectionIn(name string, categoryIDs []uint32) CollectionIn {
 	ci := CollectionIn{
 		CollectionBody: CollectionBody{
 			Name: name,
 		},
-		Category: categoryID,
+		Categories: categoryIDs,
 	}
 	return ci
 }
@@ -88,7 +88,7 @@ func NewCollection(id uint32, ci CollectionIn) Collection {
 		ID: id,
 		CollectionIn: CollectionIn{
 			CollectionBody: ci.CollectionBody,
-			Category:       ci.Category,
+			Categories:     ci.Categories,
 		},
 		InsertTime:     now,
 		LastUpdateTime: now,

--- a/model/collection_test.go
+++ b/model/collection_test.go
@@ -24,7 +24,7 @@ func TestCollection(t *testing.T) {
 	js, err = json.Marshal(c)
 	assert.NoError(t, err)
 	// log.Printf("Collection JSON: %s", string(js))
-	c.Category = 999
+	c.Categories = []uint32{999}
 	js, err = json.Marshal(c)
 	assert.NoError(t, err)
 	// log.Printf("Collection JSON: %s", string(js))

--- a/persist/postgres_collections.go
+++ b/persist/postgres_collections.go
@@ -14,17 +14,24 @@ import (
 
 // SelectCollections selects all collections
 func (p PostgresPersister) SelectCollections(ctx context.Context) ([]model.Collection, error) {
-	rows, err := p.db.QueryContext(ctx, "SELECT id, category_id, body, insert_time, last_update_time FROM collection")
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT id, array_agg(cc.category_id), body, insert_time, last_update_time
+			   FROM collection LEFT JOIN collection_category cc ON id = cc.collection_id GROUP BY id`)
 	if err != nil {
 		return nil, translateError(err)
 	}
 	defer rows.Close()
 	collections := make([]model.Collection, 0)
 	for rows.Next() {
+		var categories []int64
 		var collection model.Collection
-		err := rows.Scan(&collection.ID, &collection.Category, &collection.CollectionBody, &collection.InsertTime, &collection.LastUpdateTime)
+		err := rows.Scan(&collection.ID, pq.Array(&categories), &collection.CollectionBody, &collection.InsertTime, &collection.LastUpdateTime)
 		if err != nil {
 			return nil, translateError(err)
+		}
+		collection.Categories = make([]uint32, len(categories))
+		for i, cat := range categories {
+			collection.Categories[i] = uint32(cat)
 		}
 		collections = append(collections, collection)
 	}
@@ -38,16 +45,23 @@ func (p PostgresPersister) SelectCollectionsByID(ctx context.Context, ids []uint
 		return collections, nil
 	}
 
-	rows, err := p.db.QueryContext(ctx, "SELECT id, category_id, body, insert_time, last_update_time FROM collection WHERE id = ANY($1)", pq.Array(ids))
+	rows, err := p.db.QueryContext(ctx,
+		`SELECT id, array_agg(cc.category_id), body, insert_time, last_update_time
+			   FROM collection LEFT JOIN collection_category cc ON id = cc.collection_id WHERE id = ANY($1) GROUP BY id`, pq.Array(ids))
 	if err != nil {
 		return nil, translateError(err)
 	}
 	defer rows.Close()
 	for rows.Next() {
+		var categories []int64
 		var collection model.Collection
-		err := rows.Scan(&collection.ID, &collection.Category, &collection.CollectionBody, &collection.InsertTime, &collection.LastUpdateTime)
+		err := rows.Scan(&collection.ID, pq.Array(&categories), &collection.CollectionBody, &collection.InsertTime, &collection.LastUpdateTime)
 		if err != nil {
 			return nil, translateError(err)
+		}
+		collection.Categories = make([]uint32, len(categories))
+		for i, cat := range categories {
+			collection.Categories[i] = uint32(cat)
 		}
 		collections = append(collections, collection)
 	}
@@ -56,10 +70,13 @@ func (p PostgresPersister) SelectCollectionsByID(ctx context.Context, ids []uint
 
 // SelectOneCollection selects a single collection
 func (p PostgresPersister) SelectOneCollection(ctx context.Context, id uint32) (model.Collection, error) {
+	var categories []int64
 	var collection model.Collection
-	err := p.db.QueryRowContext(ctx, "SELECT id, category_id, body, insert_time, last_update_time FROM collection WHERE id=$1", id).Scan(
+	err := p.db.QueryRowContext(ctx,
+		`SELECT id, array_agg(cc.category_id), body, insert_time, last_update_time
+			   FROM collection LEFT JOIN collection_category cc ON id = cc.collection_id WHERE id = $1 GROUP BY id`, id).Scan(
 		&collection.ID,
-		&collection.Category,
+		pq.Array(&categories),
 		&collection.CollectionBody,
 		&collection.InsertTime,
 		&collection.LastUpdateTime,
@@ -67,38 +84,65 @@ func (p PostgresPersister) SelectOneCollection(ctx context.Context, id uint32) (
 	if err != nil {
 		return collection, translateError(err)
 	}
+	collection.Categories = make([]uint32, len(categories))
+	for i, cat := range categories {
+		collection.Categories[i] = uint32(cat)
+	}
 	return collection, nil
 }
 
 // InsertCollection inserts a CollectionBody into the database and returns the inserted Collection
 func (p PostgresPersister) InsertCollection(ctx context.Context, in model.CollectionIn) (model.Collection, error) {
 	var collection model.Collection
-	err := p.db.QueryRowContext(ctx,
-		`INSERT INTO collection (category_id, body) 
-		 VALUES ($1, $2) 
-		 RETURNING id, category_id, body, insert_time, last_update_time`,
-		in.Category, in.CollectionBody).
+	// create a transaction so collection and collection_category stay in sync
+	tx, err := p.db.Begin()
+	if err != nil {
+		return collection, translateError(err)
+	}
+	defer tx.Rollback()
+
+	err = tx.QueryRowContext(ctx,
+		`INSERT INTO collection (body) 
+		 VALUES ($1) 
+		 RETURNING id, body, insert_time, last_update_time`,
+		in.CollectionBody).
 		Scan(
 			&collection.ID,
-			&collection.Category,
 			&collection.CollectionBody,
 			&collection.InsertTime,
 			&collection.LastUpdateTime,
 		)
+	if err != nil {
+		return collection, translateError(err)
+	}
+	for _, category := range in.Categories {
+		_, err = tx.ExecContext(ctx, "INSERT INTO collection_category (collection_id, category_id) VALUES ($1, $2)", collection.ID, category)
+		if err != nil {
+			return collection, translateError(err)
+		}
+	}
+	collection.Categories = append([]uint32(nil), in.Categories...)
+	err = tx.Commit()
 	return collection, translateError(err)
 }
 
 // UpdateCollection updates a Collection in the database and returns the updated Collection
 func (p PostgresPersister) UpdateCollection(ctx context.Context, id uint32, in model.Collection) (model.Collection, error) {
 	var collection model.Collection
-	err := p.db.QueryRowContext(ctx,
-		`UPDATE collection SET body = $1, category_id = $2, last_update_time = CURRENT_TIMESTAMP 
-		 WHERE id = $3 AND last_update_time = $4
-		 RETURNING id, category_id, body, insert_time, last_update_time`,
-		in.CollectionBody, in.Category, id, in.LastUpdateTime).
+	// create a transaction so collection and collection_category stay in sync
+	tx, err := p.db.Begin()
+	if err != nil {
+		return collection, translateError(err)
+	}
+	defer tx.Rollback()
+
+	err = tx.QueryRowContext(ctx,
+		`UPDATE collection SET body = $1, last_update_time = CURRENT_TIMESTAMP 
+		 WHERE id = $2 AND last_update_time = $3
+		 RETURNING id, body, insert_time, last_update_time`,
+		in.CollectionBody, id, in.LastUpdateTime).
 		Scan(
 			&collection.ID,
-			&collection.Category,
 			&collection.CollectionBody,
 			&collection.InsertTime,
 			&collection.LastUpdateTime,
@@ -112,11 +156,39 @@ func (p PostgresPersister) UpdateCollection(ctx context.Context, id uint32, in m
 		}
 		return collection, model.NewError(model.ErrNotFound, strconv.Itoa(int(id)))
 	}
+	// delete and re-add categories (in the future we could calculate the differences and add/delete just what we need to)
+	_, err = tx.ExecContext(ctx, "DELETE FROM collection_category WHERE collection_id = $1", id)
+	if err != nil {
+		return collection, translateError(err)
+	}
+	for _, category := range in.Categories {
+		_, err = tx.ExecContext(ctx, "INSERT INTO collection_category (collection_id, category_id) VALUES ($1, $2)", collection.ID, category)
+		if err != nil {
+			return collection, translateError(err)
+		}
+	}
+	collection.Categories = append([]uint32(nil), in.Categories...)
+	err = tx.Commit()
 	return collection, translateError(err)
 }
 
 // DeleteCollection deletes a Collection
 func (p PostgresPersister) DeleteCollection(ctx context.Context, id uint32) error {
-	_, err := p.db.ExecContext(ctx, "DELETE FROM collection WHERE id = $1", id)
+	// create a transaction so collection and collection_category stay in sync
+	tx, err := p.db.Begin()
+	if err != nil {
+		return translateError(err)
+	}
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(ctx, "DELETE FROM collection_category WHERE collection_id = $1", id)
+	if err != nil {
+		return translateError(err)
+	}
+	_, err = tx.ExecContext(ctx, "DELETE FROM collection WHERE id = $1", id)
+	if err != nil {
+		return translateError(err)
+	}
+	err = tx.Commit()
 	return translateError(err)
 }

--- a/publisher/server_test.go
+++ b/publisher/server_test.go
@@ -106,7 +106,7 @@ func deleteTestCategory(p model.CategoryPersister, category *model.Category) err
 }
 
 func createTestCollection(p model.CollectionPersister, categoryID uint32) (*model.Collection, error) {
-	in := model.NewCollectionIn("Test", categoryID)
+	in := model.NewCollectionIn("Test", []uint32{categoryID})
 	in.Fields = []model.CollectionField{
 		{
 			Header: "given",

--- a/recordswriter/server_test.go
+++ b/recordswriter/server_test.go
@@ -122,7 +122,7 @@ func deleteTestCategory(p model.CategoryPersister, category *model.Category) err
 }
 
 func createTestCollection(p model.CollectionPersister, categoryID uint32) (*model.Collection, error) {
-	in := model.NewCollectionIn("Test", categoryID)
+	in := model.NewCollectionIn("Test", []uint32{categoryID})
 	created, err := p.InsertCollection(context.TODO(), in)
 	if err != nil {
 		return nil, err

--- a/server/collections_test.go
+++ b/server/collections_test.go
@@ -230,7 +230,7 @@ func makeCollectionIn(t *testing.T) (model.CollectionIn, *bytes.Buffer) {
 		CollectionBody: model.CollectionBody{
 			Name: "First",
 		},
-		Category: 1,
+		Categories: []uint32{1},
 	}
 	buf := new(bytes.Buffer)
 	enc := json.NewEncoder(buf)

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -1082,14 +1082,6 @@ var doc = `{
                 "name"
             ],
             "properties": {
-                "details_page_template": {
-                    "type": "string"
-                },
-                "field_defs": {
-                    "description": "example:\"{\\\"int_field\\\":\\\"Int\\\", \\\"string_field\\\":\\\"String\\\"}\"",
-                    "type": "object",
-                    "$ref": "#/definitions/model.FieldDefSet"
-                },
                 "id": {
                     "type": "integer",
                     "example": 999
@@ -1102,9 +1094,6 @@ var doc = `{
                 },
                 "name": {
                     "type": "string"
-                },
-                "search_results_page_template": {
-                    "type": "string"
                 }
             }
         },
@@ -1114,18 +1103,7 @@ var doc = `{
                 "name"
             ],
             "properties": {
-                "details_page_template": {
-                    "type": "string"
-                },
-                "field_defs": {
-                    "description": "example:\"{\\\"int_field\\\":\\\"Int\\\", \\\"string_field\\\":\\\"String\\\"}\"",
-                    "type": "object",
-                    "$ref": "#/definitions/model.FieldDefSet"
-                },
                 "name": {
-                    "type": "string"
-                },
-                "search_results_page_template": {
                     "type": "string"
                 }
             }
@@ -1133,14 +1111,16 @@ var doc = `{
         "model.Collection": {
             "type": "object",
             "required": [
-                "category",
+                "categories",
                 "id",
                 "name"
             ],
             "properties": {
-                "category": {
-                    "type": "integer",
-                    "example": 999
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "citation_template": {
                     "type": "string"
@@ -1195,13 +1175,15 @@ var doc = `{
         "model.CollectionIn": {
             "type": "object",
             "required": [
-                "category",
+                "categories",
                 "name"
             ],
             "properties": {
-                "category": {
-                    "type": "integer",
-                    "example": 999
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "citation_template": {
                     "type": "string"
@@ -1245,33 +1227,6 @@ var doc = `{
         },
         "model.Errors": {
             "type": "object"
-        },
-        "model.FieldDef": {
-            "type": "object",
-            "properties": {
-                "csv_heading": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "Int",
-                        "String",
-                        "Image",
-                        "Location",
-                        "Time"
-                    ]
-                }
-            }
-        },
-        "model.FieldDefSet": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/model.FieldDef"
-            }
         },
         "model.Post": {
             "type": "object",

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1071,14 +1071,6 @@
                 "name"
             ],
             "properties": {
-                "details_page_template": {
-                    "type": "string"
-                },
-                "field_defs": {
-                    "description": "example:\"{\\\"int_field\\\":\\\"Int\\\", \\\"string_field\\\":\\\"String\\\"}\"",
-                    "type": "object",
-                    "$ref": "#/definitions/model.FieldDefSet"
-                },
                 "id": {
                     "type": "integer",
                     "example": 999
@@ -1091,9 +1083,6 @@
                 },
                 "name": {
                     "type": "string"
-                },
-                "search_results_page_template": {
-                    "type": "string"
                 }
             }
         },
@@ -1103,18 +1092,7 @@
                 "name"
             ],
             "properties": {
-                "details_page_template": {
-                    "type": "string"
-                },
-                "field_defs": {
-                    "description": "example:\"{\\\"int_field\\\":\\\"Int\\\", \\\"string_field\\\":\\\"String\\\"}\"",
-                    "type": "object",
-                    "$ref": "#/definitions/model.FieldDefSet"
-                },
                 "name": {
-                    "type": "string"
-                },
-                "search_results_page_template": {
                     "type": "string"
                 }
             }
@@ -1122,14 +1100,16 @@
         "model.Collection": {
             "type": "object",
             "required": [
-                "category",
+                "categories",
                 "id",
                 "name"
             ],
             "properties": {
-                "category": {
-                    "type": "integer",
-                    "example": 999
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "citation_template": {
                     "type": "string"
@@ -1184,13 +1164,15 @@
         "model.CollectionIn": {
             "type": "object",
             "required": [
-                "category",
+                "categories",
                 "name"
             ],
             "properties": {
-                "category": {
-                    "type": "integer",
-                    "example": 999
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "citation_template": {
                     "type": "string"
@@ -1234,33 +1216,6 @@
         },
         "model.Errors": {
             "type": "object"
-        },
-        "model.FieldDef": {
-            "type": "object",
-            "properties": {
-                "csv_heading": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "Int",
-                        "String",
-                        "Image",
-                        "Location",
-                        "Time"
-                    ]
-                }
-            }
-        },
-        "model.FieldDefSet": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/model.FieldDef"
-            }
         },
         "model.Post": {
             "type": "object",

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -7,12 +7,6 @@ definitions:
     type: object
   model.Category:
     properties:
-      details_page_template:
-        type: string
-      field_defs:
-        $ref: '#/definitions/model.FieldDefSet'
-        description: example:"{\"int_field\":\"Int\", \"string_field\":\"String\"}"
-        type: object
       id:
         example: 999
         type: integer
@@ -22,32 +16,23 @@ definitions:
         type: string
       name:
         type: string
-      search_results_page_template:
-        type: string
     required:
     - id
     - name
     type: object
   model.CategoryIn:
     properties:
-      details_page_template:
-        type: string
-      field_defs:
-        $ref: '#/definitions/model.FieldDefSet'
-        description: example:"{\"int_field\":\"Int\", \"string_field\":\"String\"}"
-        type: object
       name:
-        type: string
-      search_results_page_template:
         type: string
     required:
     - name
     type: object
   model.Collection:
     properties:
-      category:
-        example: 999
-        type: integer
+      categories:
+        items:
+          type: integer
+        type: array
       citation_template:
         type: string
       fields:
@@ -70,7 +55,7 @@ definitions:
       name:
         type: string
     required:
-    - category
+    - categories
     - id
     - name
     type: object
@@ -87,9 +72,10 @@ definitions:
     type: object
   model.CollectionIn:
     properties:
-      category:
-        example: 999
-        type: integer
+      categories:
+        items:
+          type: integer
+        type: array
       citation_template:
         type: string
       fields:
@@ -105,7 +91,7 @@ definitions:
       name:
         type: string
     required:
-    - category
+    - categories
     - name
     type: object
   model.CollectionMapping:
@@ -121,25 +107,6 @@ definitions:
     type: object
   model.Errors:
     type: object
-  model.FieldDef:
-    properties:
-      csv_heading:
-        type: string
-      name:
-        type: string
-      type:
-        enum:
-        - Int
-        - String
-        - Image
-        - Location
-        - Time
-        type: string
-    type: object
-  model.FieldDefSet:
-    items:
-      $ref: '#/definitions/model.FieldDef'
-    type: array
   model.Post:
     properties:
       collection:

--- a/uglyui/package-lock.json
+++ b/uglyui/package-lock.json
@@ -11551,6 +11551,11 @@
         }
       }
     },
+    "vue-multiselect": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
+      "integrity": "sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w=="
+    },
     "vue-router": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.3.4.tgz",

--- a/uglyui/package.json
+++ b/uglyui/package.json
@@ -16,6 +16,7 @@
     "nprogress": "^0.2.0",
     "tabulator-tables": "^4.6.3",
     "vue": "^2.6.11",
+    "vue-multiselect": "^2.1.6",
     "vue-router": "^3.3.4",
     "vuelidate": "^0.7.5",
     "vuex": "^3.4.0"

--- a/uglyui/src/components/Collection.vue
+++ b/uglyui/src/components/Collection.vue
@@ -4,7 +4,8 @@
       <router-link class="post-link" :to="{ name: 'collection-edit', params: { cid: collection.id } }">{{
         collection.name
       }}</router-link>
-      (in {{ category.name }})
+      <!--      (in <span v-for="(category, $ix) in categories" :key="$ix">{{ category.name }}</span-->
+      (in {{ categories.map(cat => cat.name).join(", ") }})
     </div>
   </div>
 </template>
@@ -13,7 +14,7 @@
 export default {
   props: {
     collection: Object,
-    category: Object
+    categories: Array
   }
 };
 </script>

--- a/uglyui/src/views/CategoriesList.vue
+++ b/uglyui/src/views/CategoriesList.vue
@@ -27,7 +27,7 @@ export default {
   computed: {
     collectionsForCategory() {
       return category => {
-        return this.collections.collectionsList.filter(coll => coll.category === category.id);
+        return this.collections.collectionsList.filter(coll => coll.categories.includes(category.id));
       };
     },
     ...mapState(["categories", "collections"])

--- a/uglyui/src/views/CollectionsList.vue
+++ b/uglyui/src/views/CollectionsList.vue
@@ -5,7 +5,7 @@
       v-for="collection in collections.collectionsList"
       :key="collection.id"
       :collection="collection"
-      :category="categoryForCollection(collection)"
+      :categories="categoriesForCollection(collection)"
     />
   </div>
 </template>
@@ -25,9 +25,9 @@ export default {
     });
   },
   computed: {
-    categoryForCollection() {
+    categoriesForCollection() {
       return collection => {
-        return this.categories.categoriesList.find(cat => cat.id === collection.category);
+        return this.categories.categoriesList.filter(cat => collection.categories.includes(cat.id));
       };
     },
     ...mapState(["categories", "collections"])


### PR DESCRIPTION
* add a new collection_category table and populate it from the old collection.category field
* join collection table with collection_category table when reading collection
* begin a transaction around create, update, delete collection to ensure collection_category is kept in sync
->> this would have been easier if we simply put the categoryIDs array in the json, but then we'd lose ref integrity, so I think it was worth it

make collection create/edit in UI a multi-select