### PR TITLE
add cors

### DIFF
--- a/server/app.go
+++ b/server/app.go
@@ -143,9 +143,9 @@ func (app App) verifyToken(next http.Handler) http.Handler {
 func (app App) NewRouter() *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
-	r.HandleFunc(app.baseURL.Path+"/", app.GetIndex).Methods("GET", "OPTIONS")
-	r.HandleFunc(app.baseURL.Path+"/health", app.GetHealth).Methods("GET", "OPTIONS")
-	r.HandleFunc(app.baseURL.Path+"/index.html", app.GetIndex).Methods("GET", "OPTIONS")
+	r.HandleFunc(app.baseURL.Path+"/", app.GetIndex).Methods("GET")
+	r.HandleFunc(app.baseURL.Path+"/health", app.GetHealth).Methods("GET")
+	r.HandleFunc(app.baseURL.Path+"/index.html", app.GetIndex).Methods("GET")
 
 	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.GetAllCategories))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.PostCategory))).Methods("POST")

--- a/server/app.go
+++ b/server/app.go
@@ -83,6 +83,10 @@ func (app App) GetHealth(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// we need a handler for options. This handler won't actually get invoked; it's just needed so the CORS middleware will get invoked
+func (app App) OptionsNoop(w http.ResponseWriter, req *http.Request) {
+}
+
 func (app App) verifyToken(next http.Handler) http.Handler {
 	if app.authDisabled {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -147,34 +151,49 @@ func (app App) NewRouter() *mux.Router {
 	r.HandleFunc(app.baseURL.Path+"/health", app.GetHealth).Methods("GET")
 	r.HandleFunc(app.baseURL.Path+"/index.html", app.GetIndex).Methods("GET")
 
-	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.GetAllCategories))).Methods("GET", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/categories", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.GetAllCategories))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.PostCategory))).Methods("POST")
-	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.GetCategory))).Methods("GET", "OPTIONS")
+
+	r.Handle(app.baseURL.Path+"/categories/{id}", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.GetCategory))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.PutCategory))).Methods("PUT")
 	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.DeleteCategory))).Methods("DELETE")
 
-	r.Handle(app.baseURL.Path+"/collections", app.verifyToken(http.HandlerFunc(app.GetCollections))).Methods("GET", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/collections", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/collections", app.verifyToken(http.HandlerFunc(app.GetCollections))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/collections", app.verifyToken(http.HandlerFunc(app.PostCollection))).Methods("POST")
-	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.GetCollection))).Methods("GET", "OPTIONS")
+
+	r.Handle(app.baseURL.Path+"/collections/{id}", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.GetCollection))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.PutCollection))).Methods("PUT")
 	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.DeleteCollection))).Methods("DELETE")
 
-	r.Handle(app.baseURL.Path+"/content", app.verifyToken(http.HandlerFunc(app.PostContentRequest))).Methods("POST", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/content", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/content", app.verifyToken(http.HandlerFunc(app.PostContentRequest))).Methods("POST")
 
-	r.Handle(app.baseURL.Path+"/posts", app.verifyToken(http.HandlerFunc(app.GetPosts))).Methods("GET", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/posts", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/posts", app.verifyToken(http.HandlerFunc(app.GetPosts))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/posts", app.verifyToken(http.HandlerFunc(app.PostPost))).Methods("POST")
-	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.GetPost))).Methods("GET", "OPTIONS")
+
+	r.Handle(app.baseURL.Path+"/posts/{id}", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.GetPost))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.PutPost))).Methods("PUT")
 	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.DeletePost))).Methods("DELETE")
 
-	r.Handle(app.baseURL.Path+"/records", app.verifyToken(http.HandlerFunc(app.GetRecords))).Methods("GET", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/records", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/records", app.verifyToken(http.HandlerFunc(app.GetRecords))).Methods("GET")
 
-	r.Handle(app.baseURL.Path+"/settings", app.verifyToken(http.HandlerFunc(app.GetSettings))).Methods("GET", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/settings", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.Handle(app.baseURL.Path+"/settings", app.verifyToken(http.HandlerFunc(app.GetSettings))).Methods("GET")
 	r.Handle(app.baseURL.Path+"/settings", app.verifyToken(http.HandlerFunc(app.PutSettings))).Methods("PUT")
 
 	// search doesn't require a token for now
-	r.HandleFunc(app.baseURL.Path+"/search", app.Search).Methods("GET", "OPTIONS")
-	r.HandleFunc(app.baseURL.Path+"/search/{id}", app.SearchByID).Methods("GET", "OPTIONS")
+	r.Handle(app.baseURL.Path+"/search", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.HandleFunc(app.baseURL.Path+"/search", app.Search).Methods("GET")
+
+	r.Handle(app.baseURL.Path+"/search/{id}", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
+	r.HandleFunc(app.baseURL.Path+"/search/{id}", app.SearchByID).Methods("GET")
 
 	return r
 }

--- a/server/app.go
+++ b/server/app.go
@@ -143,38 +143,38 @@ func (app App) verifyToken(next http.Handler) http.Handler {
 func (app App) NewRouter() *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
-	r.HandleFunc(app.baseURL.Path+"/", app.GetIndex).Methods("GET")
-	r.HandleFunc(app.baseURL.Path+"/health", app.GetHealth).Methods("GET")
-	r.HandleFunc(app.baseURL.Path+"/index.html", app.GetIndex).Methods("GET")
+	r.HandleFunc(app.baseURL.Path+"/", app.GetIndex).Methods("GET", "OPTIONS")
+	r.HandleFunc(app.baseURL.Path+"/health", app.GetHealth).Methods("GET", "OPTIONS")
+	r.HandleFunc(app.baseURL.Path+"/index.html", app.GetIndex).Methods("GET", "OPTIONS")
 
-	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.GetAllCategories))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.GetAllCategories))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/categories", app.verifyToken(http.HandlerFunc(app.PostCategory))).Methods("POST")
-	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.GetCategory))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.GetCategory))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.PutCategory))).Methods("PUT")
 	r.Handle(app.baseURL.Path+"/categories/{id}", app.verifyToken(http.HandlerFunc(app.DeleteCategory))).Methods("DELETE")
 
-	r.Handle(app.baseURL.Path+"/collections", app.verifyToken(http.HandlerFunc(app.GetCollections))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/collections", app.verifyToken(http.HandlerFunc(app.GetCollections))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/collections", app.verifyToken(http.HandlerFunc(app.PostCollection))).Methods("POST")
-	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.GetCollection))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.GetCollection))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.PutCollection))).Methods("PUT")
 	r.Handle(app.baseURL.Path+"/collections/{id}", app.verifyToken(http.HandlerFunc(app.DeleteCollection))).Methods("DELETE")
 
-	r.Handle(app.baseURL.Path+"/content", app.verifyToken(http.HandlerFunc(app.PostContentRequest))).Methods("POST")
+	r.Handle(app.baseURL.Path+"/content", app.verifyToken(http.HandlerFunc(app.PostContentRequest))).Methods("POST", "OPTIONS")
 
-	r.Handle(app.baseURL.Path+"/posts", app.verifyToken(http.HandlerFunc(app.GetPosts))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/posts", app.verifyToken(http.HandlerFunc(app.GetPosts))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/posts", app.verifyToken(http.HandlerFunc(app.PostPost))).Methods("POST")
-	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.GetPost))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.GetPost))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.PutPost))).Methods("PUT")
 	r.Handle(app.baseURL.Path+"/posts/{id}", app.verifyToken(http.HandlerFunc(app.DeletePost))).Methods("DELETE")
 
-	r.Handle(app.baseURL.Path+"/records", app.verifyToken(http.HandlerFunc(app.GetRecords))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/records", app.verifyToken(http.HandlerFunc(app.GetRecords))).Methods("GET", "OPTIONS")
 
-	r.Handle(app.baseURL.Path+"/settings", app.verifyToken(http.HandlerFunc(app.GetSettings))).Methods("GET")
+	r.Handle(app.baseURL.Path+"/settings", app.verifyToken(http.HandlerFunc(app.GetSettings))).Methods("GET", "OPTIONS")
 	r.Handle(app.baseURL.Path+"/settings", app.verifyToken(http.HandlerFunc(app.PutSettings))).Methods("PUT")
 
 	// search doesn't require a token for now
-	r.HandleFunc(app.baseURL.Path+"/search", app.Search).Methods("GET")
-	r.HandleFunc(app.baseURL.Path+"/search/{id}", app.SearchByID).Methods("GET")
+	r.HandleFunc(app.baseURL.Path+"/search", app.Search).Methods("GET", "OPTIONS")
+	r.HandleFunc(app.baseURL.Path+"/search/{id}", app.SearchByID).Methods("GET", "OPTIONS")
 
 	return r
 }

--- a/server/server.go
+++ b/server/server.go
@@ -184,6 +184,11 @@ func main() {
 		httpSwagger.DomID("#swagger-ui"),
 	))
 	r.NotFoundHandler = http.HandlerFunc(NotFound)
+	corsMiddleware := handlers.CORS(
+		handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
+		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"}),
+		handlers.AllowedOrigins([]string{"*"}))
+	r.Use(corsMiddleware)
 
 	if env.IsLambda {
 		// Lambda-specific setup
@@ -210,21 +215,10 @@ func main() {
 		if env.BaseURL.Scheme == "https" {
 			log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%s", env.BaseURL.Port()),
 				"server.crt", "server.key",
-				handlers.LoggingHandler(
-					os.Stdout,
-					handlers.CORS(
-						handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
-						handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"}),
-						handlers.AllowedOrigins([]string{"*"}))(r)),
-			))
+				handlers.LoggingHandler(os.Stdout, r)))
 		} else {
 			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", env.BaseURL.Port()),
-				handlers.LoggingHandler(os.Stdout,
-					handlers.CORS(
-						handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "Authorization"}),
-						handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"}),
-						handlers.AllowedOrigins([]string{"*"}))(r)),
-			))
+				handlers.LoggingHandler(os.Stdout, r)))
 		}
 	}
 }


### PR DESCRIPTION
I learned something about API Gateway's CORS support the other day. It appears that if you have a * endpoint it doesn't automatically answer the OPTIONS request. I suppose in hindsight that makes sense - it doesn't know if the endpoint being requested even exists.

We had added CORS support when running locally, but not when running under lambda. So I made CORS a middleware.

I also learned something about gorilla mux. Gorilla doesn't call middleware functions unless the path *and method* match an existing route. So I had to add OPTIONS as additional methods on all of the routes.