### PR TITLE
Fix some issues with DynamoDB

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -274,6 +274,8 @@ func fromError(e *model.Error) *Error {
 		httpStatus = http.StatusBadRequest
 	case model.ErrConcurrentUpdate:
 		httpStatus = http.StatusConflict
+	case model.ErrConflict:
+		httpStatus = http.StatusConflict
 	case model.ErrNotFound:
 		httpStatus = http.StatusNotFound
 	case model.ErrRequired:

--- a/api/records.go
+++ b/api/records.go
@@ -53,6 +53,7 @@ func (api API) AddRecord(ctx context.Context, in model.RecordIn) (*model.Record,
 	if e != nil {
 		return nil, NewError(e)
 	}
+	log.Printf("[DEBUG] Added record ID %d", record.ID)
 	return record, nil
 }
 

--- a/api/search.go
+++ b/api/search.go
@@ -443,6 +443,8 @@ func indexRecord(record *model.Record, post *model.Post, collection *model.Colle
 		_, givenFound := data["given"]
 		_, surnameFound := data["surname"]
 		if !givenFound && !surnameFound {
+			log.Printf("[DEBUG] No given name or surname found for record %#v, mappings %#v, role %s",
+				record, collection.Mappings, role)
 			continue
 		}
 

--- a/deploy/awslambda/cms-aurora.cf.yaml
+++ b/deploy/awslambda/cms-aurora.cf.yaml
@@ -260,6 +260,7 @@ Resources:
                 - s3:GetObjectACL
                 - s3:PutObject
                 - s3:PutObjectACL
+                - s3:DeleteObject
               Resource:
                 Fn::Join:
                   - ''
@@ -385,6 +386,7 @@ Resources:
                 - s3:GetObjectACL
                 - s3:PutObject
                 - s3:PutObjectACL
+                - s3:DeleteObject
               Resource:
                 Fn::Join:
                   - ''
@@ -466,6 +468,7 @@ Resources:
                 - s3:GetObjectACL
                 - s3:PutObject
                 - s3:PutObjectACL
+                - s3:DeleteObject
               Resource:
                 Fn::Join:
                   - ''

--- a/deploy/awslambda/cms-dynamodb.cf.yaml
+++ b/deploy/awslambda/cms-dynamodb.cf.yaml
@@ -245,6 +245,7 @@ Resources:
                 - s3:GetObjectACL
                 - s3:PutObject
                 - s3:PutObjectACL
+                - s3:DeleteObject
               Resource:
                 Fn::Join:
                   - ''
@@ -342,6 +343,7 @@ Resources:
                 - s3:GetObjectACL
                 - s3:PutObject
                 - s3:PutObjectACL
+                - s3:DeleteObject
               Resource:
                 Fn::Join:
                   - ''
@@ -409,6 +411,7 @@ Resources:
                 - s3:GetObjectACL
                 - s3:PutObject
                 - s3:PutObjectACL
+                - s3:DeleteObject
               Resource:
                 Fn::Join:
                   - ''

--- a/model/error.go
+++ b/model/error.go
@@ -12,6 +12,8 @@ type ErrorCode string
 func (code ErrorCode) Matches(err error) bool {
 	if e, ok := err.(*Error); ok {
 		return e.Code == code
+	} else if e, ok := err.(Error); ok {
+		return e.Code == code
 	}
 	return false
 }
@@ -22,6 +24,7 @@ const (
 	ErrNotFound         ErrorCode = "NOT_FOUND"
 	ErrBadReference     ErrorCode = "BAD_REFERENCE"
 	ErrConcurrentUpdate ErrorCode = "CONCURRENT_UPDATE"
+	ErrConflict         ErrorCode = "CONFICT"
 	ErrOther            ErrorCode = "OTHER"
 )
 
@@ -30,6 +33,7 @@ var errorMessages = map[ErrorCode]string{
 	ErrNotFound:         "'%s' was not found",
 	ErrBadReference:     "Non-existent reference. ID: '%s', Type: '%s'",
 	ErrConcurrentUpdate: "Database LastUpdateTime (%s) doesn't match provided value (%s).",
+	ErrConflict:         "Transaction conflict.",
 	ErrOther:            "Unknown error: %s",
 }
 

--- a/model/error_test.go
+++ b/model/error_test.go
@@ -10,4 +10,11 @@ import (
 func TestError(t *testing.T) {
 	e := model.NewError(model.ErrRequired, "some_field")
 	assert.NotNil(t, e)
+
+	assert.True(t, model.ErrRequired.Matches(e))
+
+	var err error
+	err = model.NewError(model.ErrConflict)
+	assert.False(t, model.ErrRequired.Matches(err))
+	assert.True(t, model.ErrConflict.Matches(err))
 }

--- a/persist/dynamo/collections.go
+++ b/persist/dynamo/collections.go
@@ -261,6 +261,9 @@ func (p Persister) InsertCollection(ctx context.Context, in model.CollectionIn) 
 							log.Printf("[ERROR] Failed to put collection %#v. twii: %#v err: %v", coll, twii, err)
 							return nil, model.NewError(model.ErrOther, err.Error())
 						}
+					} else if *r.Code == "TransactionConflict" {
+						log.Printf("[ERROR] TransactionConflict when putting collection %#v. twii: %#v err: %v", coll, twii, err)
+						return nil, model.NewError(model.ErrConflict)
 					} else {
 						log.Printf("[ERROR] Failed to put collection %#v. twii: %#v err: %v", coll, twii, err)
 						return nil, model.NewError(model.ErrOther, err.Error())
@@ -412,6 +415,9 @@ func (p Persister) UpdateCollection(ctx context.Context, id uint32, in model.Col
 							log.Printf("[ERROR] Failed to put collection %#v. twii: %#v err: %v", coll, twii, err)
 							return nil, model.NewError(model.ErrOther, err.Error())
 						}
+					} else if *r.Code == "TransactionConflict" {
+						log.Printf("[ERROR] TransactionConflict when putting collection %#v. twii: %#v err: %v", coll, twii, err)
+						return nil, model.NewError(model.ErrConflict)
 					} else {
 						log.Printf("[ERROR] Failed to put collection %#v. twii: %#v err: %v", coll, twii, err)
 						return nil, model.NewError(model.ErrOther, err.Error())

--- a/persist/dynamo/posts.go
+++ b/persist/dynamo/posts.go
@@ -160,6 +160,9 @@ func (p Persister) InsertPost(ctx context.Context, in model.PostIn) (*model.Post
 							log.Printf("[ERROR] Failed to put post %#v. twii: %#v err: %v", post, twii, err)
 							return nil, model.NewError(model.ErrOther, err.Error())
 						}
+					} else if *r.Code == "TransactionConflict" {
+						log.Printf("[ERROR] TransactionConflict when putting post %#v. twii: %#v err: %v", post, twii, err)
+						return nil, model.NewError(model.ErrConflict)
 					} else {
 						log.Printf("[ERROR] Failed to put post %#v. twii: %#v err: %v", post, twii, err)
 						return nil, model.NewError(model.ErrOther, err.Error())
@@ -255,6 +258,9 @@ func (p Persister) UpdatePost(ctx context.Context, id uint32, in model.Post) (*m
 							log.Printf("[ERROR] Failed to put post %#v. twii: %#v err: %v", post, twii, err)
 							return nil, model.NewError(model.ErrOther, err.Error())
 						}
+					} else if *r.Code == "TransactionConflict" {
+						log.Printf("[ERROR] TransactionConflict when putting post %#v. twii: %#v err: %v", post, twii, err)
+						return nil, model.NewError(model.ErrConflict)
 					} else {
 						log.Printf("[ERROR] Failed to put post %#v. twii: %#v err: %v", post, twii, err)
 						return nil, model.NewError(model.ErrOther, err.Error())

--- a/persist/dynamo/records.go
+++ b/persist/dynamo/records.go
@@ -183,7 +183,6 @@ func (p Persister) InsertRecord(ctx context.Context, in model.RecordIn) (*model.
 			ConditionExpression: aws.String("attribute_exists(" + pkName + ") AND attribute_exists(" + skName + ")"),
 		},
 	}
-	// log.Printf("[DEBUG] Creating record")
 	twi[1] = &dynamodb.TransactWriteItem{
 		Put: &dynamodb.Put{
 			TableName:           p.tableName,
@@ -213,6 +212,9 @@ func (p Persister) InsertRecord(ctx context.Context, in model.RecordIn) (*model.
 							log.Printf("[ERROR] Failed to put record %#v. twii: %#v err: %v", record, twii, err)
 							return nil, model.NewError(model.ErrOther, err.Error())
 						}
+					} else if *r.Code == "TransactionConflict" {
+						log.Printf("[ERROR] TransactionConflict when putting record %#v. twii: %#v err: %v", record, twii, err)
+						return nil, model.NewError(model.ErrConflict)
 					} else {
 						log.Printf("[ERROR] Failed to put record %#v. twii: %#v err: %v", record, twii, err)
 						return nil, model.NewError(model.ErrOther, err.Error())
@@ -297,6 +299,9 @@ func (p Persister) UpdateRecord(ctx context.Context, id uint32, in model.Record)
 							log.Printf("[ERROR] Failed to put record %#v. twii: %#v err: %v", record, twii, err)
 							return nil, model.NewError(model.ErrOther, err.Error())
 						}
+					} else if *r.Code == "TransactionConflict" {
+						log.Printf("[ERROR] TransactionConflict when putting record %#v. twii: %#v err: %v", record, twii, err)
+						return nil, model.NewError(model.ErrConflict)
 					} else {
 						log.Printf("[ERROR] Failed to put record %#v. twii: %#v err: %v", record, twii, err)
 						return nil, model.NewError(model.ErrOther, err.Error())

--- a/recordswriter/server.go
+++ b/recordswriter/server.go
@@ -136,16 +136,17 @@ func processMessage(ctx context.Context, ap *api.API, rawMsg []byte) error {
 			errs = e
 		}
 	}
-	if errs != nil {
-		return errs
-	}
 	close(out)
 
-	// update post.recordsStatus = load complete
-	post.RecordsStatus = model.PostLoadComplete
-	_, errs = ap.UpdatePost(ctx, post.ID, *post)
 	if errs != nil {
-		log.Printf("[ERROR] UpdatePost %v\n", errs)
+		post.RecordsStatus = model.PostDraft
+	} else {
+		post.RecordsStatus = model.PostLoadComplete
+	}
+	_, err = ap.UpdatePost(ctx, post.ID, *post)
+	if err != nil {
+		log.Printf("[ERROR] UpdatePost %v\n", err)
+		return err
 	}
 
 	return errs


### PR DESCRIPTION
Included are:
* A missing S3 delete permission I discovered (non DynamoDB-related).
* When the RecordsWriter lambda fails, reset the post to Draft.
* Workaround for a DynamoDB transaction issue I discovered.

Here's a [forum posting](https://forums.aws.amazon.com/thread.jspa?messageID=950580#950580) I wrote for the transaction issue:

> I'm using TransactWriteItems with a ConditionCheck to check a foreign key constraint. So I have two items in my transaction, the ConditionCheck, which checks for the existence of a parent item in the table, and a Put, which inserts a child item, which contains an attribute that references the parent. When I concurrently insert multiple children that all reference the same parent, I often get a TransactionCanceledException, where the CancellationReason is "TransactionConflict" and its position in the array corresponds to the condition check. As far as I can tell, the parent item isn't being written to concurrently. Is there some other reason I would be getting a conflict in this situation?

Pending an actual fix, I've implemented retries in the RecordsWriter code. It will retry up to three times, with backoffs of 1, 10 and 100ms. That seems to resolve the issue, but I haven't done any load testing. A large CSV might not fare as well.