### PR TITLE
Small deploy enhancement and a possible fix

### DIFF
--- a/deploy/awslambda/cms-aurora.cf.yaml
+++ b/deploy/awslambda/cms-aurora.cf.yaml
@@ -81,7 +81,6 @@ Resources:
     Properties:
       ApiId: !Ref OurRootsCMSApi
       RouteKey: "ANY /api/{proxy+}"
-      # RouteKey: "$default"
       AuthorizationType: NONE
       Target: !Join
         - /
@@ -205,6 +204,14 @@ Resources:
   # GETs to /* go to index.html in the bucket root
   UIRoute:
     Type: "AWS::ApiGatewayV2::Route"
+    # Attempt to workaround case where most-specfic matching didn't seem to work on initial deploy
+    DependsOn:
+      - ApiRoute
+      - CSSRoute
+      - IMGRoute
+      - JSRoute
+      - FaviconRoute
+      - CallbackRoute
     Properties:
       ApiId: !Ref OurRootsCMSApi
       RouteKey: "GET /{proxy+}"

--- a/deploy/awslambda/cms-dynamodb.cf.yaml
+++ b/deploy/awslambda/cms-dynamodb.cf.yaml
@@ -67,7 +67,6 @@ Resources:
     Properties:
       ApiId: !Ref OurRootsCMSApi
       RouteKey: "ANY /api/{proxy+}"
-      # RouteKey: "$default"
       AuthorizationType: NONE
       Target: !Join
         - /
@@ -191,6 +190,14 @@ Resources:
   # GETs to /* go to index.html in the bucket root
   UIRoute:
     Type: "AWS::ApiGatewayV2::Route"
+    # Attempt to workaround case where most-specfic matching didn't seem to work on initial deploy
+    DependsOn:
+      - ApiRoute
+      - CSSRoute
+      - IMGRoute
+      - JSRoute
+      - FaviconRoute
+      - CallbackRoute
     Properties:
       ApiId: !Ref OurRootsCMSApi
       RouteKey: "GET /{proxy+}"

--- a/deploy/awslambda/cms-infra-aurora.cf.yaml
+++ b/deploy/awslambda/cms-infra-aurora.cf.yaml
@@ -6,6 +6,12 @@ Parameters:
     Description: Name of this CMS deployment
     Type: String
 
+  ESAdminCIDR:
+    Description: CIDR block to be granted access to Elasticsearch
+    Type: String
+    Default: '0.0.0.0/0'
+    AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
+
   VpcCIDR:
     Description: Please enter the IP range (CIDR notation) for this VPC
     Type: String
@@ -35,6 +41,9 @@ Parameters:
     Type: String
     Default: 10.192.21.0/24
     AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$'
+
+Conditions:
+  ESGrantIPAccess: !Not [ !Equals [ !Ref ESAdminCIDR , '0.0.0.0/0' ] ]
 
 Resources:
   VPC:
@@ -456,6 +465,17 @@ Resources:
               AWS: !Ref AWS::AccountId
             Action: 'es:ESHttp*'
             Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${EnvironmentName}-es/*'
+          - Fn::If:
+            - ESGrantIPAccess
+            - Effect: Allow
+              Principal:
+                AWS: '*'
+              Action: 'es:ESHttp*'
+              Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${EnvironmentName}-es/*'
+              Condition:
+                IpAddress:
+                  aws:SourceIp: !Ref ESAdminCIDR
+            - Ref: AWS::NoValue
       # LogPublishingOptions:
       #   SEARCH_SLOW_LOGS:
       #     CloudWatchLogsLogGroupArn: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:${EnvironmentName}/ElasticSearch/search-slow-logs'

--- a/deploy/awslambda/cms-infra-dynamodb.cf.yaml
+++ b/deploy/awslambda/cms-infra-dynamodb.cf.yaml
@@ -5,6 +5,14 @@ Parameters:
   EnvironmentName:
     Description: Name of this CMS deployment
     Type: String
+  ESAdminCIDR:
+    Description: CIDR block to be granted access to Elasticsearch
+    Type: String
+    Default: '0.0.0.0/0'
+    AllowedPattern: '((\d{1,3})\.){3}\d{1,3}/\d{1,2}'
+
+Conditions:
+  ESGrantIPAccess: !Not [ !Equals [ !Ref ESAdminCIDR , '0.0.0.0/0' ] ]
 
 Resources:
   SiteBucket:
@@ -106,6 +114,18 @@ Resources:
               AWS: !Ref AWS::AccountId
             Action: 'es:ESHttp*'
             Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${EnvironmentName}-es/*'
+          - Fn::If:
+            - ESGrantIPAccess
+            - Effect: Allow
+              Principal:
+                AWS: '*'
+              Action: 'es:ESHttp*'
+              Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${EnvironmentName}-es/*'
+              Condition:
+                IpAddress:
+                  aws:SourceIp: !Ref ESAdminCIDR
+            - Ref: AWS::NoValue
+
       # LogPublishingOptions:
       #   SEARCH_SLOW_LOGS:
       #     CloudWatchLogsLogGroupArn: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:${EnvironmentName}/ElasticSearch/search-slow-logs'

--- a/deploy/awslambda/deploy-infra.sh
+++ b/deploy/awslambda/deploy-infra.sh
@@ -2,6 +2,7 @@
 set -e
 ENVIRONMENT_NAME="${ENVIRONMENT_NAME:?}"
 USE_POSTGRES="${USE_POSTGRES:-true}"
+ES_ADMIN_CIDR="${ES_ADMIN_CIDR:-0.0.0.0/0}"
 # DOMAIN_NAME="${DOMAIN_NAME:?}"
 # set -x
 s3_bucket_name="${ENVIRONMENT_NAME}-deploy"
@@ -18,7 +19,7 @@ else
 fi
 echo Processing CloudFormation...
 aws cloudformation package --template-file "${template_file}" --output-template-file output-cms-infra.cf.yaml --s3-bucket $s3_bucket_name
-aws cloudformation deploy --template-file output-cms-infra.cf.yaml --stack-name "${ENVIRONMENT_NAME}-infra" --parameter-overrides "EnvironmentName=${ENVIRONMENT_NAME}" --capabilities CAPABILITY_IAM
+aws cloudformation deploy --template-file output-cms-infra.cf.yaml --stack-name "${ENVIRONMENT_NAME}-infra" --parameter-overrides "EnvironmentName=${ENVIRONMENT_NAME}" "ESAdminCIDR=${ES_ADMIN_CIDR}" --capabilities CAPABILITY_IAM
 
 if [ "${USE_POSTGRES}" == "true" ]
 then


### PR DESCRIPTION
1. Optionally open up an IP range for HTTP access to ElasticSearch. This can be enabled by setting `ES_ADMIN_CIDR` when running `deploy-infra.sh`. So `ES_ADMIN_CIDR='72.87.57.111/32'` opens up access to that IP address, and `ES_ADMIN_CIDR=72.87.57.0/24` to the /24 subnet.
2. I recreated my environment and API Gateway request routing was broken until I did a manual save in the console. I added some dependencies to the CF and it didn't happen again. Of course it's probably just intermittent, but the dependencies won't hurt.