### PR TITLE
dont require authentication to get places by prefix

### DIFF
--- a/server/app.go
+++ b/server/app.go
@@ -196,7 +196,7 @@ func (app App) NewRouter() *mux.Router {
 	r.HandleFunc(app.baseURL.Path+"/search/{id}", app.SearchByID).Methods("GET")
 
 	r.Handle(app.baseURL.Path+"/places", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
-	r.Handle(app.baseURL.Path+"/places", app.verifyToken(http.HandlerFunc(app.GetPlacesByPrefix))).Methods("GET")
+	r.HandleFunc(app.baseURL.Path+"/places", http.HandlerFunc(app.GetPlacesByPrefix)).Methods("GET")
 
 	r.Handle(app.baseURL.Path+"/currentuser", http.HandlerFunc(app.OptionsNoop)).Methods("OPTIONS")
 	r.Handle(app.baseURL.Path+"/currentuser", app.verifyToken(http.HandlerFunc(app.GetCurrentUser))).Methods("GET")

--- a/server/places_test.go
+++ b/server/places_test.go
@@ -14,7 +14,6 @@ import (
 func TestGetPlacesByPrefix(t *testing.T) {
 	am := &api.ApiMock{}
 	app := NewApp().API(am)
-	app.authDisabled = true
 	r := app.NewRouter()
 
 	// Empty result


### PR DESCRIPTION
The endpoint to return the top N places for a typed-in prefix doesn't seem that sensitive, and users using the search form are going to have to hit it frequently. Rather than protect it, just let it be open, at least for now.