### PR TITLE
Elasticsearch coders

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ tilt down                       # clean up docker images when done
                                   # alternatively, run docker-compose down
 ```
 
-# Building 
+## Building 
 
 In the `ourroots` directory, run `make` to run unit tests and build.
 
-# Saving and restoring elasticsearch volume data
+## Saving and restoring elasticsearch volume data
 ### creates /tmp/cms_esdata.tar.bz2 from cms_esdata
 ```
 docker run --rm -v cms_esdata:/volume -v /tmp:/backup alpine tar -cjf /backup/cms_esdata.tar.bz2 -C /volume ./
@@ -63,8 +63,18 @@ docker run --rm -v cms_esdata:/volume -v /tmp:/backup alpine tar -cjf /backup/cm
 docker run --rm -v cms_esdata:/volume -v /tmp:/backup alpine sh -c "rm -rf /volume/* /volume/..?* /volume/.[!.]* ; tar -C /volume/ -xjf /backup/cms_esdata.tar.bz2"
 ```
 
-# Populating database tables
+## Configuration
 
+### Populating the database tables
+
+To populate the place and name-variants dictionaries, run the following script:
 ```
 cd db && ./db_load_full.sh <postgres-user> <postgres-password> <postgres-host> <postgres-port>
 ```
+
+### Customizing the search index
+
+By default, the narrow name coder is NYSIIS, and the broad name coder is Soundex. You can change this by editing 
+`elasticsearch/elasticsearch_schema.json` and modifying the encoder values on lines 39 and 43 before running the 
+`es_setup.sh` script. Possible values are: nysiis, metaphone, double_metaphone, beider_morse, soundex, refined_soundex, 
+daitch_mokotoff, caverphone1, caverphone2, cologne, koelnerphonetik, and haasephonetik. 

--- a/elasticsearch/elasticsearch_schema.json
+++ b/elasticsearch/elasticsearch_schema.json
@@ -18,27 +18,27 @@
               "asciifolding"
             ]
           },
-          "refined_soundex": {
+          "broad_coder": {
             "tokenizer": "lowercase",
             "filter": [
               "asciifolding",
-              "refined_soundex_filter"
+              "broad_filter"
             ]
           },
-          "nysiis": {
+          "narrow_coder": {
             "tokenizer": "lowercase",
             "filter": [
               "asciifolding",
-              "nysiis_filter"
+              "narrow_filter"
             ]
           }
         },
         "filter": {
-          "refined_soundex_filter": {
+          "broad_filter": {
             "type": "phonetic",
-            "encoder": "refined_soundex"
+            "encoder": "soundex"
           },
-          "nysiis_filter": {
+          "narrow_filter": {
             "type": "phonetic",
             "encoder": "nysiis"
           }
@@ -65,7 +65,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -73,7 +73,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -91,7 +91,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -99,7 +99,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -118,7 +118,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -126,7 +126,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -144,7 +144,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -152,7 +152,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -171,7 +171,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -179,7 +179,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -197,7 +197,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -205,7 +205,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -224,7 +224,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -232,7 +232,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -250,7 +250,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -258,7 +258,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -277,7 +277,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -285,7 +285,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -303,7 +303,7 @@
         "fields": {
           "narrow": {
             "type": "text",
-            "analyzer": "nysiis",
+            "analyzer": "narrow_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,
@@ -311,7 +311,7 @@
           },
           "broad": {
             "type": "text",
-            "analyzer": "refined_soundex",
+            "analyzer": "broad_coder",
             "doc_values": false,
             "index_options": "docs",
             "norms": false,


### PR DESCRIPTION
explain how to change name coders in README; switch from refined-soundex to soundex for default broad name coder